### PR TITLE
feat: modernize site styling

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -9,6 +9,7 @@
         content="Información de contacto, dirección y horarios de Óptica Alberche El Tiemblo en El Tiemblo.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
         integrity="sha512-..." crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
 

--- a/css/hero-section.css
+++ b/css/hero-section.css
@@ -29,6 +29,7 @@
     z-index: 2; /* Asegura que el contenido esté por encima de la capa oscura */
     padding: 20px;
     max-width: 800px;
+    animation: fadeIn 1.2s ease-out both;
 }
 
 .hero-content h1 {
@@ -107,5 +108,16 @@
     .hero-content .button {
         padding: 10px 25px;
         font-size: 0.9rem;
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -12,6 +12,8 @@
     --box-shadow-light: 0 4px 10px rgba(0,0,0,0.08); /* Sombra más suave */
     --box-shadow-hover: 0 8px 20px rgba(0,0,0,0.15); /* Sombra para hover */
     --transition-speed: 0.3s ease;
+    --primary-gradient: linear-gradient(135deg, #316d2e 0%, #56ab2f 100%);
+    --primary-gradient-hover: linear-gradient(135deg, #295a26 0%, #3d6d2e 100%);
 }
 
 /* Base styles */
@@ -21,11 +23,15 @@
     padding: 0;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 body {
-    font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Poppins', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     line-height: 1.6;
     color: var(--text-color);
-    background-color: var(--light-bg);
+    background: linear-gradient(180deg, var(--light-bg) 0%, #e9ecef 100%);
 }
 
 .container {
@@ -56,9 +62,10 @@ a:hover {
 
 /* Header */
 header {
-    background-color: var(--white);
+    background-color: rgba(255,255,255,0.9);
+    backdrop-filter: blur(8px);
     padding: 1rem 0;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid rgba(0,0,0,0.05);
     box-shadow: var(--box-shadow-light);
     position: sticky;
     top: 0;
@@ -165,13 +172,13 @@ header .container {
 /* Buttons */
 .button, .button-small {
     display: inline-block;
-    background-color: var(--primary-color);
+    background: var(--primary-gradient);
     color: var(--white);
     padding: 12px 28px; /* Ligeramente más padding */
     border-radius: var(--border-radius);
     text-decoration: none;
     font-weight: bold;
-    transition: background-color var(--transition-speed), transform 0.2s ease;
+    transition: background var(--transition-speed), transform 0.2s ease;
     border: none;
     cursor: pointer;
     font-size: 1rem;
@@ -179,7 +186,7 @@ header .container {
 }
 
 .button:hover, .button-small:hover {
-    background-color: var(--primary-dark);
+    background: var(--primary-gradient-hover);
     transform: translateY(-2px); /* Efecto sutil al hover */
     text-decoration: none;
 }
@@ -285,12 +292,14 @@ main {
 }
 
 .info-card {
-    background-color: var(--light-bg);
+    background-color: rgba(255,255,255,0.8);
+    border: 1px solid rgba(0,0,0,0.05);
     padding: 30px; /* Más padding */
     border-radius: var(--border-radius);
     text-align: center;
     box-shadow: 0 2px 8px rgba(0,0,0,0.05); /* Sombra más suave */
     transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    backdrop-filter: blur(4px);
 }
 
 .info-card:hover {
@@ -355,7 +364,8 @@ main {
 }
 
 .product-card {
-    background-color: var(--white);
+    background-color: rgba(255,255,255,0.9);
+    border: 1px solid rgba(0,0,0,0.05);
     border-radius: var(--border-radius);
     box-shadow: var(--box-shadow-light);
     padding: 25px; /* Más padding */
@@ -364,6 +374,7 @@ main {
     flex-direction: column;
     align-items: center;
     transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    backdrop-filter: blur(4px);
 }
 
 .product-card:hover {

--- a/favoritos.html
+++ b/favoritos.html
@@ -9,6 +9,7 @@
         content="Consulta tus productos favoritos guardados de Óptica Alberche El Tiemblo para tu próxima visita.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
         integrity="sha512-..." crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         content="Bienvenido a Óptica Alberche El Tiemblo. Descubre nuestro catálogo de gafas de sol, graduadas y lentillas. Marca tus favoritos y visítanos en El Tiemblo.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
         integrity="sha512-..." crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/hero-section.css">
 </head>

--- a/productos.html
+++ b/productos.html
@@ -9,6 +9,7 @@
         content="Catálogo completo de gafas de sol, graduadas, lentillas y accesorios en Óptica Alberche El Tiemblo.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
         integrity="sha512-..." crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
 


### PR DESCRIPTION
## Summary
- adopt Poppins via Google Fonts across pages for cleaner typography
- add gradient backgrounds, glassy header and enhanced buttons
- polish info and product cards with subtle borders and blur
- animate hero content on load

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6085a4748332bece71609c4b8241